### PR TITLE
Support split of YR_RULES into YR_RULE list

### DIFF
--- a/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
@@ -2,16 +2,16 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET.Core</id>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/Microsoft/libyara.NET/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <title>Microsoft.O365.Security.Native.libyara.NET.Core</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Only targeted for 64-bit .NET Core build project.</description>
-    <releaseNotes>Initial release</releaseNotes>
+    <releaseNotes>Support split of YR_RULES into YR_RULE list</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <tags>yara libyara .NET.Core virustotal managed 4.0.1 net46</tags>
+    <tags>yara libyara .NET.Core virustotal managed 4.0.2 net46</tags>
   </metadata>
   <files>
     <file src="x64\Release\*.dll" target="lib\net46\" />

--- a/Microsoft.O365.Security.Native.libyara.NET.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.nuspec
@@ -2,16 +2,16 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET</id>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/Microsoft/libyara.NET/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <title>Microsoft.O365.Security.Native.libyara.NET</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Support both 32-bit and 64-bit of .NET framework 4.6</description>
-    <releaseNotes>Update native yara bits; remove dependencies on external native dlls</releaseNotes>
+    <releaseNotes>Support split of YR_RULES into YR_RULE list</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <tags>yara libyara virustotal managed 4.0.1</tags>
+    <tags>yara libyara virustotal managed 4.0.2</tags>
   </metadata>
   <files>
     <!-- Runtime libraries for x86 -->

--- a/Tests/Content/CombinedRules.yara
+++ b/Tests/Content/CombinedRules.yara
@@ -1,0 +1,17 @@
+rule ExampleRule1
+{
+    strings:
+        $ex = "example 1"
+
+    condition:
+        $ex
+}
+
+rule ExampleRule2
+{
+    strings:
+        $ex = "example 2"
+
+    condition:
+        $ex
+}

--- a/Tests/Content/CombinedRules.yara
+++ b/Tests/Content/CombinedRules.yara
@@ -1,4 +1,4 @@
-rule ExampleRule1
+rule ExampleRule1 : HelloTag
 {
     strings:
         $ex = "example 1"
@@ -7,7 +7,7 @@ rule ExampleRule1
         $ex
 }
 
-rule ExampleRule2
+rule ExampleRule2 : HelloTag HelloTag2
 {
     strings:
         $ex = "example 2"

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -73,6 +73,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="describe_Compiler.cs" />
+    <Compile Include="describe_Rules.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="describe_QuickScan.cs" />
   </ItemGroup>
@@ -94,6 +95,11 @@
     <Content Include="Content\InvalidRule.yara">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Content\CombinedRules.yara">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Tests/describe_Compiler.cs
+++ b/Tests/describe_Compiler.cs
@@ -74,5 +74,11 @@ namespace Tests
 
             compiler.AddRuleString("import \"hash\" rule test { condition: hash.md5(0, 100) == \"abc\"}");
         }
+
+        [TestMethod]
+        public void given_file_of_combined_rules_it_should_compile()
+        {
+            compiler.AddRuleFile(".\\Content\\CombinedRules.yara");
+        }
     }
 }

--- a/Tests/describe_Rules.cs
+++ b/Tests/describe_Rules.cs
@@ -24,14 +24,30 @@ namespace Tests
         }
 
         [TestMethod]
-        public void it_should_split_ruleset()
+        public void it_should_split_ruleset_when_one_rule_in_one_file()
+        {
+            using (var ruleset = GetRuleSet(".\\Content\\BasicRule.yara"))
+            {
+                var rules = ruleset.GetRules();
+
+                Assert.AreEqual(1, rules.Count);
+                Assert.AreEqual("BasicRule", rules[0].Identifier);
+                Assert.AreEqual(0, rules[0].Tags.Count);
+            }
+        }
+
+        [TestMethod]
+        public void it_should_split_ruleset_when_multiple_rules_in_one_file()
         {
             using (var ruleset = GetRuleSet(".\\Content\\CombinedRules.yara"))
             {
                 var rules = ruleset.GetRules();
+
                 Assert.AreEqual(2, rules.Count);
                 Assert.AreEqual("ExampleRule1", rules[0].Identifier);
+                Assert.AreEqual(1, rules[0].Tags.Count);
                 Assert.AreEqual("ExampleRule2", rules[1].Identifier);
+                Assert.AreEqual(2, rules[1].Tags.Count);
             }
         }
 

--- a/Tests/describe_Rules.cs
+++ b/Tests/describe_Rules.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using libyaraNET;
+
+namespace Tests
+{
+    [TestClass]
+    public class describe_Rules
+    {
+        Compiler compiler;
+        YaraContext ctx;
+
+        [TestInitialize]
+        public void before_each()
+        {
+            ctx = new YaraContext();
+            compiler = new Compiler();
+        }
+
+        [TestCleanup]
+        public void after_each()
+        {
+            ctx.Dispose();
+        }
+
+        [TestMethod]
+        public void it_should_split_ruleset()
+        {
+            using (var ruleset = GetRuleSet(".\\Content\\CombinedRules.yara"))
+            {
+                var rules = ruleset.GetRules();
+                Assert.AreEqual(2, rules.Count);
+                Assert.AreEqual("ExampleRule1", rules[0].Identifier);
+                Assert.AreEqual("ExampleRule2", rules[1].Identifier);
+            }
+        }
+
+        private Rules GetRuleSet(string rulePath)
+        {
+            compiler.AddRuleFile(rulePath);
+            return compiler.GetRules();
+        }
+    }
+}

--- a/libyara.NET/Rules.h
+++ b/libyara.NET/Rules.h
@@ -50,7 +50,7 @@ namespace libyaraNET {
         }
 
         /// <summary>
-        /// Iterate the compiled Rules set(i.e. YR_RULES) and
+        /// Split the compiled Rules set(i.e. YR_RULES) to
         /// get a list of compiled Rule objects(i.e. YR_RULE)
         /// </summary>
         List<Rule^>^ GetRules()

--- a/libyara.NET/Rules.h
+++ b/libyara.NET/Rules.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "Rule.h"
+
 #include <yara.h>
 
 using namespace System;
+using namespace System::Collections::Generic;
 
 namespace libyaraNET {
 
@@ -44,6 +47,23 @@ namespace libyaraNET {
             rules = nullptr;
 
             return temp;
+        }
+
+        /// <summary>
+        /// Iterate the compiled Rules set(i.e. YR_RULES) and
+        /// get a list of compiled Rule objects(i.e. YR_RULE)
+        /// </summary>
+        List<Rule^>^ GetRules()
+        {
+            auto results = gcnew List<Rule^>();
+
+            YR_RULE* rule;
+            yr_rules_foreach(rules, rule)
+            {
+                results->Add(gcnew Rule(rule));
+            }
+
+            return results;
         }
     };
 }


### PR DESCRIPTION
Currently ```libyaraNET.Compiler``` compiles Yara rule string into a compiled ```libyaraNET.Rules``` object, which users cannot read too much useful information from.

The new version of ```libyaraNET``` supports split of this set into a list of single ```libyaraNET.Rule``` objects. Users can read ```Identifier```, ```Tags``` from each rule.