### PR TITLE
Expose support for accessing YARA meta-fields.

### DIFF
--- a/libyara.NET/Rule.h
+++ b/libyara.NET/Rule.h
@@ -16,6 +16,7 @@ namespace libyaraNET {
     public:
         property String^ Identifier;
         property List<String^>^ Tags;
+        property List<Tuple<String^, String^>^>^ Metas;
 
         /// <summary>
         /// Create an empty Rule. Useful for testing.
@@ -36,6 +37,16 @@ namespace libyaraNET {
             yr_rule_tags_foreach(rule, tag)
             {
                 Tags->Add(marshal_as<String^>(tag));
+            }
+
+            yr_rule_metas_foreach(rule, meta)
+            {
+                // Meta fields have two main strings. The name ("identifier"), and what it's equal to ("string").
+                Tuple<String^, String^>^ storeme =
+                    gcnew Tuple<String^, String^>(
+                        marshal_as<String^>(meta->identifier),
+                        marshal_as<String^>(meta->string));
+                Metas->Add(storeme);
             }
         }
     };


### PR DESCRIPTION
Hey,

This PR exposes a "Metas" field for rule instances. Say you have a rule like:

```
rule Something
{
  meta:
    risk = "This one was seen during project ABCD!" 

  strings:
    $something = "something" nocase wide ascii

  condition:
    $something
}
```

It's useful to be able to access it in your application leveraging this library:
```
                    foreach (var m in scanresult.MatchingRule.Metas)
                    {
                        // We've got some risk from this hit?
                        if (m.Item1 == "risk")
                        {
                            // Let's populate that in the UI!
                        }
                    }
```

It's my hope that this change can be pushed to nuget as well :)