### PR TITLE
Fix issue preventing scanning of file paths with unicode cahracters

### DIFF
--- a/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
@@ -10,7 +10,7 @@
     <title>Microsoft.O365.Security.Native.libyara.NET.Core</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Only targeted for 64-bit .NET Core build project.</description>
     <releaseNotes>
-      - Fix issue preventing file paths with unicode cahracters from being scanned
+      - Fix issue preventing file paths with unicode characters from being scanned
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET.Core</id>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/Microsoft/libyara.NET/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
@@ -10,7 +10,7 @@
     <title>Microsoft.O365.Security.Native.libyara.NET.Core</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Only targeted for 64-bit .NET Core build project.</description>
     <releaseNotes>
-      - Update YARA to 4.2.3
+      - Fix issue preventing file paths with unicode cahracters from being scanned
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/Microsoft.O365.Security.Native.libyara.NET.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET</id>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/Microsoft/libyara.NET/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
@@ -10,7 +10,7 @@
     <title>Microsoft.O365.Security.Native.libyara.NET</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Support both 32-bit and 64-bit of .NET framework 4.6</description>
     <releaseNotes>
-      - Update YARA to 4.2.3
+      - Fix issue preventing file paths with unicode cahracters from being scanned
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/Microsoft.O365.Security.Native.libyara.NET.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.nuspec
@@ -10,7 +10,7 @@
     <title>Microsoft.O365.Security.Native.libyara.NET</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Support both 32-bit and 64-bit of .NET framework 4.6</description>
     <releaseNotes>
-      - Fix issue preventing file paths with unicode cahracters from being scanned
+      - Fix issue preventing file paths with unicode characters from being scanned
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/Tests/Content/菜单模块.txt
+++ b/Tests/Content/菜单模块.txt
@@ -1,0 +1,2 @@
+﻿This is the file that says hello world once on this line,
+and hello world a second time on the second line.

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -89,6 +89,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Content\菜单模块.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Content\HelloWorld.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Tests/describe_QuickScan.cs
+++ b/Tests/describe_QuickScan.cs
@@ -11,12 +11,23 @@ namespace Tests
     {
         readonly string rulesPath = ".\\Content\\BasicRule.yara";
         readonly string testPath = ".\\Content\\HelloWorld.txt";
-
+        readonly string unicodeTestPath = ".\\Content\\菜单模块.txt";
 
         [TestMethod]
         public void it_should_scan_files()
         {
             var results = QuickScan.File(testPath, rulesPath);
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(1, results[0].Matches.Count);
+            Assert.AreEqual(2, results[0].Matches["$hw"].Count);
+            Assert.AreEqual(0x1eUL, results[0].Matches["$hw"][0].Offset);
+        }
+
+        [TestMethod]
+        public void it_should_scan_files_with_unicode_filenames()
+        {
+            var results = QuickScan.File(unicodeTestPath, rulesPath);
 
             Assert.AreEqual(1, results.Count);
             Assert.AreEqual(1, results[0].Matches.Count);

--- a/libyara.NET/Scanner.h
+++ b/libyara.NET/Scanner.h
@@ -72,13 +72,21 @@ namespace libyaraNET {
                 throw gcnew FileNotFoundException(path);
 
             auto results = gcnew List<ScanResult^>();
-            auto nativePath = marshal_as<std::string>(path);
+            auto nativePath = marshal_as<std::wstring>(path);
+            auto fd = CreateFile(nativePath.c_str(),
+                GENERIC_READ,
+                FILE_SHARE_READ,
+                NULL,
+                OPEN_EXISTING,
+                0,
+                NULL);
+
             GCHandleWrapper resultsHandle(results);
 
             ErrorUtility::ThrowOnError(
-                yr_rules_scan_file(
+                yr_rules_scan_fd(
                     rules,
-                    nativePath.c_str(),
+                    fd,
                     (int)flags,
                     callbackPtr,
                     resultsHandle.GetPointer(),


### PR DESCRIPTION
Scanning files with unicode characters in their paths results in the exception "Yara error code 3", which translates to ERROR_COULD_NOT_OPEN_FILE.  This is due to the libyara's use of const char* for the filename in the yr_scanner_scan_file api.

This PR opts for the use of yr_scanner_scan_fd, so we can use const wchar_t* supported by CreateFile.