### PR TITLE
Update YARA and fix file handle leak

### DIFF
--- a/Microsoft.O365.Security.Native.Libyara.nuspec
+++ b/Microsoft.O365.Security.Native.Libyara.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.Libyara</id>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/Microsoft/libyara.NET/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/libyara.NET</projectUrl>
@@ -10,7 +10,7 @@
     <title>Microsoft.O365.Security.Native.Libyara</title>
     <description>VirusTotal's libyara native nuget package built with vcpkg. This nuget package is a dependency of libyara.NET project.</description>
     <summary>x86 and x64 binary versions are available for Windows in this package. Projects that use this package should use 'x86' or 'Win32' as the platform name to select the x86 binaries and use 'x64' to select the x64 binaries.</summary>
-    <releaseNotes>Update YARA to 4.2.3</releaseNotes>
+    <releaseNotes>Update YARA to 4.3.0</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>native libyara vcpkg odspsecurity</tags>
   </metadata>

--- a/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET.Core</id>
-    <version>4.2.1.1</version>
+    <version>4.2.2</version>
     <authors>Microsoft</authors>
     <license type="expression">BSD-3-Clause</license>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
@@ -10,7 +10,8 @@
     <title>Microsoft.O365.Security.Native.libyara.NET.Core</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Only targeted for 64-bit .NET Core build project.</description>
     <releaseNotes>
-      - Add support for .NET 6.0
+      - Update YARA to 4.3.0
+      - Close file handle after scanning
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/Microsoft.O365.Security.Native.libyara.NET.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET</id>
-    <version>4.2.1.1</version>
+    <version>4.2.2</version>
     <authors>Microsoft</authors>
     <license type="expression">BSD-3-Clause</license>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
@@ -10,7 +10,8 @@
     <title>Microsoft.O365.Security.Native.libyara.NET</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Support both 32-bit and 64-bit of .NET framework 4.6</description>
     <releaseNotes>
-      - Fix issue preventing file paths with unicode characters from being scanned
+      - Update YARA to 4.3.0
+      - Close file handle after scanning
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # libyara.NET
 A .NET wrapper for libyara that provides a simplified API for developing tools in C# and PowerShell. This library targets .NET 4.6.
 
-This library is built against the [Microsoft.O365.Security.Native.Libyara](https://www.nuget.org/packages/Microsoft.O365.Security.Native.Libyara/) package which is based on VirusTotal's [yara](https://github.com/VirusTotal/yara/) built with [vcpkg](https://github.com/Microsoft/vcpkg/). This library is currently based on yara 4.0.2 per the [vcpkg port](https://github.com/microsoft/vcpkg/tree/master/ports/yara). We will update [yara](https://github.com/VirusTotal/yara/) version to include the latest features and bug fixes if necessary.
+This library is built against the [Microsoft.O365.Security.Native.Libyara](https://www.nuget.org/packages/Microsoft.O365.Security.Native.Libyara/) package which is based on VirusTotal's [yara](https://github.com/VirusTotal/yara/) built with [vcpkg](https://github.com/Microsoft/vcpkg/). This library is currently based on yara 4.3.0 per the [vcpkg port](https://github.com/microsoft/vcpkg/tree/master/ports/yara). We will update [yara](https://github.com/VirusTotal/yara/) version to include the latest features and bug fixes if necessary.
 
 This library is avaiable in forms of two NuGet packages, depending on your project types:
 

--- a/libyara.NET.Core/libyara.NET.Core.vcxproj
+++ b/libyara.NET.Core/libyara.NET.Core.vcxproj
@@ -109,12 +109,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
+    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
   </Target>
 </Project>

--- a/libyara.NET.Core/libyara.NET.Core.vcxproj
+++ b/libyara.NET.Core/libyara.NET.Core.vcxproj
@@ -95,6 +95,7 @@
     <ClInclude Include="..\libyara.NET\Rule.h" />
     <ClInclude Include="..\libyara.NET\Rules.h" />
     <ClInclude Include="..\libyara.NET\YaraContext.h" />
+    <ClInclude Include="..\libyara.NET\FileHandleWrapper.h" />
     <ClInclude Include="..\libyara.NET\Scanner.h" />
   </ItemGroup>
   <ItemGroup>

--- a/libyara.NET.Core/libyara.NET.Core.vcxproj.filters
+++ b/libyara.NET.Core/libyara.NET.Core.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClInclude Include="..\libyara.NET\Meta.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\libyara.NET\FileHandleWrapper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\libyara.NET\packages.config" />

--- a/libyara.NET/FileHandleWrapper.h
+++ b/libyara.NET/FileHandleWrapper.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <Windows.h>
+
+namespace libyaraNET {
+
+    struct file_handle
+    {
+    private:
+        HANDLE handle_;
+
+    public:
+        // has to be explicit otherwise this binds better than the move ctor
+        template <typename... Args>
+        explicit file_handle(Args&&... args)
+            : handle_(CreateFile(std::forward<Args>(args)...)) { }
+
+        // wrap existing handle
+        file_handle(HANDLE handle)
+            : handle_(handle) { }
+
+        // hide cctor
+        file_handle(const file_handle&) = delete;
+
+        // hide assignment
+        file_handle& operator=(const file_handle& other) = delete;
+
+        // move ctor to prevent closing handle with copies
+        file_handle(file_handle&& other)
+            : handle_(other.handle_)
+        {
+            other.handle_ = INVALID_HANDLE_VALUE;
+        }
+
+        ~file_handle()
+        {
+            if (is_invalid()) return;
+
+            CloseHandle(handle_);
+        }
+
+        operator HANDLE() const { return handle_; }
+
+        bool is_invalid() const { return handle_ == INVALID_HANDLE_VALUE; }
+    };
+}

--- a/libyara.NET/Scanner.h
+++ b/libyara.NET/Scanner.h
@@ -81,6 +81,9 @@ namespace libyaraNET {
                 0,
                 NULL);
 
+            if (fd == INVALID_HANDLE_VALUE)
+                throw gcnew FileNotFoundException(path);
+
             GCHandleWrapper resultsHandle(results);
 
             ErrorUtility::ThrowOnError(

--- a/libyara.NET/Scanner.h
+++ b/libyara.NET/Scanner.h
@@ -92,6 +92,8 @@ namespace libyaraNET {
                     resultsHandle.GetPointer(),
                     TimeoutSeconds));
 
+            CloseHandle(fd);
+
             return results;
         }
 

--- a/libyara.NET/Scanner.h
+++ b/libyara.NET/Scanner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Exceptions.h"
+#include "FileHandleWrapper.h"
 #include "GCHandleWrapper.h"
 #include "Rules.h"
 #include "ScanResult.h"
@@ -73,15 +74,15 @@ namespace libyaraNET {
 
             auto results = gcnew List<ScanResult^>();
             auto nativePath = marshal_as<std::wstring>(path);
-            auto fd = CreateFile(nativePath.c_str(),
+            file_handle fd(nativePath.c_str(),
                 GENERIC_READ,
                 FILE_SHARE_READ,
-                NULL,
+                (LPSECURITY_ATTRIBUTES)NULL,
                 OPEN_EXISTING,
                 0,
-                NULL);
+                (HANDLE)NULL);
 
-            if (fd == INVALID_HANDLE_VALUE)
+            if (fd.is_invalid())
                 throw gcnew FileNotFoundException(path);
 
             GCHandleWrapper resultsHandle(results);
@@ -94,8 +95,6 @@ namespace libyaraNET {
                     callbackPtr,
                     resultsHandle.GetPointer(),
                     TimeoutSeconds));
-
-            CloseHandle(fd);
 
             return results;
         }

--- a/libyara.NET/libyara.NET.vcxproj
+++ b/libyara.NET/libyara.NET.vcxproj
@@ -113,12 +113,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
+    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.5\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
   </Target>
 </Project>

--- a/libyara.NET/libyara.NET.vcxproj
+++ b/libyara.NET/libyara.NET.vcxproj
@@ -99,6 +99,7 @@
     <ClInclude Include="Rule.h" />
     <ClInclude Include="Rules.h" />
     <ClInclude Include="YaraContext.h" />
+    <ClInclude Include="FileHandleWrapper.h" />
     <ClInclude Include="Scanner.h" />
   </ItemGroup>
   <ItemGroup>

--- a/libyara.NET/libyara.NET.vcxproj.filters
+++ b/libyara.NET/libyara.NET.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClInclude Include="Meta.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FileHandleWrapper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/libyara.NET/packages.config
+++ b/libyara.NET/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.O365.Security.Native.Libyara" version="1.0.4" targetFramework="native" />
+  <package id="Microsoft.O365.Security.Native.Libyara" version="1.0.5" targetFramework="native" />
 </packages>


### PR DESCRIPTION
- Update YARA to 4.3.0
- Close file handle after scanning (fixes #31)

After merging this PR, I will rebuild and publish the updated `libyara` native nuget, then rebuild libyara.NET (which consumes the native `libyara` nuget) and publish.