### PR TITLE
Add Runtime Identifiers for TestApp and Tests projects

### DIFF
--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
+    <RuntimeIdentifier>win-$(Platform)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
+    <RuntimeIdentifier>win-$(Platform)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adding runtime identifiers to get the build to pass in Azure DevOps