### PR TITLE
Fix: Build failures

### DIFF
--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
-    <Platforms>x64;x86</Platforms>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
-    <Platforms>x64</Platforms>
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <Platforms>x64;x86</Platforms>
+    <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
-    <RuntimeIdentifier Condition=" '$(Platform)' == 'x64' ">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition=" '$(Platform)' == 'x86' ">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -4,7 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
-    <RuntimeIdentifier>win-$(Platform)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition=" '$(Platform)' == 'x64' ">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition=" '$(Platform)' == 'x86' ">win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
-    <RuntimeIdentifier>win-$(Platform)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition=" '$(Platform)' == 'x64' ">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition=" '$(Platform)' == 'x86' ">win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
-    <Platforms>x64;x86</Platforms>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
-    <Platforms>x64</Platforms>
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <Platforms>x64;x86</Platforms>
+    <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
-    <RuntimeIdentifier Condition=" '$(Platform)' == 'x64' ">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition=" '$(Platform)' == 'x86' ">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update runtime identifiers to include win7-x64 and win7-x86 for Tests and TestApp