### PR TITLE
Revert to yara 4.2.3 due to re-initialization bug with Authenticode parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # libyara.NET
 A .NET wrapper for libyara that provides a simplified API for developing tools in C# and PowerShell. This library targets .NET 4.6.
 
-This library is built against the [Microsoft.O365.Security.Native.Libyara](https://www.nuget.org/packages/Microsoft.O365.Security.Native.Libyara/) package which is based on VirusTotal's [yara](https://github.com/VirusTotal/yara/) built with [vcpkg](https://github.com/Microsoft/vcpkg/). This library is currently based on yara 4.3.0 per the [vcpkg port](https://github.com/microsoft/vcpkg/tree/master/ports/yara). We will update [yara](https://github.com/VirusTotal/yara/) version to include the latest features and bug fixes if necessary.
+This library is built against the [Microsoft.O365.Security.Native.Libyara](https://www.nuget.org/packages/Microsoft.O365.Security.Native.Libyara/) package which is based on VirusTotal's [yara](https://github.com/VirusTotal/yara/) built with [vcpkg](https://github.com/Microsoft/vcpkg/). This library is currently based on yara 4.2.3 per the [vcpkg port](https://github.com/microsoft/vcpkg/tree/master/ports/yara). We will update [yara](https://github.com/VirusTotal/yara/) version to include the latest features and bug fixes if necessary.
 
 This library is avaiable in forms of two NuGet packages, depending on your project types:
 

--- a/libyara.NET.Core/libyara.NET.Core.vcxproj
+++ b/libyara.NET.Core/libyara.NET.Core.vcxproj
@@ -110,12 +110,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
+    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
   </Target>
 </Project>

--- a/libyara.NET/libyara.NET.vcxproj
+++ b/libyara.NET/libyara.NET.vcxproj
@@ -114,12 +114,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
+    <Import Project="..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets" Condition="Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.6\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.O365.Security.Native.Libyara.1.0.4\build\native\Microsoft.O365.Security.Native.Libyara.targets'))" />
   </Target>
 </Project>

--- a/libyara.NET/packages.config
+++ b/libyara.NET/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.O365.Security.Native.Libyara" version="1.0.6" targetFramework="native" />
+  <package id="Microsoft.O365.Security.Native.Libyara" version="1.0.4" targetFramework="native" />
 </packages>


### PR DESCRIPTION
`yara` 4.3.0 includes changes to the pe module's support for Authenticode parsing ([ref](https://github.com/VirusTotal/yara/pull/1623/files)). Unfortunately, the new Authenticode parsing code throws if you `yr_initialize()`, `yr_finalize()`, and then `yr_initialize()` again in the same process.

This looks like a bug, not by-design behavior.

We think it's likely that consumers of libyara.NET are doing this sort of "initialize and tear down on-demand, multiple times in the same process" behavior since it has worked in the past. We're temporarily reverting back to `yara` 4.2.3 and will log a GitHub issue on the `yara` project to fix the re-iniitalization bug.