### PR TITLE
Added functions for external variable definition

### DIFF
--- a/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET.Core</id>
-    <version>4.2.2</version>
+    <version>4.2.3</version>
     <authors>Microsoft</authors>
     <license type="expression">BSD-3-Clause</license>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
@@ -10,8 +10,8 @@
     <title>Microsoft.O365.Security.Native.libyara.NET.Core</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Only targeted for 64-bit .NET Core build project.</description>
     <releaseNotes>
-      - Update YARA to 4.3.0
-      - Close file handle after scanning
+      - Revert to yara 4.2.3 due to re-initialization bug with Authenticode parsing
+      - Added functions for external variable definition at compile time
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/Microsoft.O365.Security.Native.libyara.NET.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET</id>
-    <version>4.2.2</version>
+    <version>4.2.3</version>
     <authors>Microsoft</authors>
     <license type="expression">BSD-3-Clause</license>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
@@ -10,8 +10,8 @@
     <title>Microsoft.O365.Security.Native.libyara.NET</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Support both 32-bit and 64-bit of .NET framework 4.6</description>
     <releaseNotes>
-      - Update YARA to 4.3.0
-      - Close file handle after scanning
+      - Revert to yara 4.2.3 due to re-initialization bug with Authenticode parsing
+      - Added functions for external variable definition at compile time
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>yara libyara virustotal</tags>

--- a/libyara.NET/Compiler.h
+++ b/libyara.NET/Compiler.h
@@ -93,6 +93,63 @@ namespace libyaraNET {
         }
 
         /// <summary>
+        /// Add external variable (integer).
+        /// </summary>
+        void AddExternalVarInteger(String^ identifier, uint64_t value)
+        {
+            auto identifierStr = marshal_as<std::string>(identifier);
+
+            yr_compiler_define_integer_variable(
+                compiler,
+                identifierStr.c_str(),
+                value
+            );
+        }
+
+        /// <summary>
+        /// Add external variable (float).
+        /// </summary>
+        void AddExternalVarFloat(String^ identifier, double value)
+        {
+            auto identifierStr = marshal_as<std::string>(identifier);
+
+            yr_compiler_define_float_variable(
+                compiler,
+                identifierStr.c_str(),
+                value
+            );
+        }
+
+        /// <summary>
+        /// Add external variable (boolean).
+        /// </summary>
+        void AddExternalVarBoolean(String^ identifier, bool value)
+        {
+            auto identifierStr = marshal_as<std::string>(identifier);
+
+            yr_compiler_define_boolean_variable(
+                compiler,
+                identifierStr.c_str(),
+                value ? (int)1 : (int)0
+            );
+        }
+
+        /// <summary>
+        /// Add external variable (string).
+        /// </summary>
+        void AddExternalVarString(String^ identifier, String^ value)
+        {
+            auto identifierStr = marshal_as<std::string>(identifier);
+            auto valueStr = marshal_as<std::string>(value);
+
+            yr_compiler_define_string_variable(
+                compiler,
+                identifierStr.c_str(),
+                valueStr.c_str()
+            );
+        }
+
+        /// <summary>
         /// Get the compiled Rules object.
         /// </summary>
         Rules^ GetRules()


### PR DESCRIPTION
The libyara API allows to define variables for usage inside yara rules. See: [yara docs](https://yara.readthedocs.io/en/stable/capi.html#defining-external-variables)

I've added the four functions to be able to add those variables according to their type with the corresponding _**yr_compiler_define_XXXX_variable**_ functions.