### PR TITLE
Fix <Link> element in targets file of native package for ARM64.

### DIFF
--- a/Microsoft.O365.Security.Native.Libyara.nuspec
+++ b/Microsoft.O365.Security.Native.Libyara.nuspec
@@ -14,9 +14,8 @@
       that use this package should use 'x86' or 'Win32' as the platform name to select the x86
       binaries, use 'x64' to select the x64 binaries and use 'ARM64' to select ARM64 binaries.</summary>
     <releaseNotes>
-      Version 1.1.0:
-      - Update yara to 4.5.1
-      - Add support for Windows ARM64
+      Version 1.1.1:
+      - Fix Linker Tools Error LNK2028 when built for Windows ARM64
     </releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>native libyara vcpkg odspsecurity</tags>

--- a/Microsoft.O365.Security.Native.Libyara.targets
+++ b/Microsoft.O365.Security.Native.Libyara.targets
@@ -30,10 +30,10 @@
       <AdditionalLibraryDirectories>
         $(MSBuildThisFileDirectory)..\..\lib\native\x64\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
-    <Lib Condition="'$(Platform)' == 'ARM64'">
+    <Link Condition="'$(Platform)' == 'ARM64'">
       <AdditionalDependencies>libcrypto.lib;libyara.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>
         $(MSBuildThisFileDirectory)..\..\lib\native\ARM64\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-    </Lib>
+    </Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
The <Link> element in targets file of native package for ARM64 is missing, which causes the build for ARM64 to fail with the linker error LNK2028.

I modified the local targets file with the changes in this PR, then the managed wrappers compile and unit tests pass.