### PR TITLE
Add support for .net 8.0. Remove support for net 6.0

### DIFF
--- a/GenerateRefAssemblies.ps1
+++ b/GenerateRefAssemblies.ps1
@@ -13,7 +13,7 @@ if (Test-Path ".\ref") {
 
 $platforms = @("x64", "Win32", "ARM64")
 $configurations = @("Debug", "Release")
-$targetFrameworks = @("net6.0", "net462")
+$targetFrameworks = @("net8.0", "net462")
 $targetAssemblyName = "libyara.NET.dll"
 
 $generated = @()
@@ -26,7 +26,7 @@ $platforms | ForEach-Object {
             $targetAssembly = ".\$platform\$configuration\$targetFramework\$targetAssemblyName"
             if (($generated -notcontains $targetFramework) -and (Test-Path $targetAssembly)) {
                 Write-Host "Generating reference assembly for $targetAssembly"
-                & $refasmer -v -O "ref\$targetFramework" -c $targetAssembly
+                & $refasmer -v --omit-non-api-members=false -O "ref\$targetFramework" -c $targetAssembly
                 if (Test-Path ".\ref\$targetFramework\$targetAssemblyName") {
                     Write-Host "Reference assembly for $targetFramework generated successfully."
                     $generated += $targetFramework

--- a/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET.Core</id>
-    <version>4.5.1</version>
+    <version>4.5.1.2</version>
     <authors>Microsoft</authors>
     <license type="expression">BSD-3-Clause</license>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>
@@ -10,6 +10,10 @@
     <title>Microsoft.O365.Security.Native.libyara.NET.Core</title>
     <description>.NET wrapper for libyara built in C++ CLI used to easily incorporate yara into C# or PowerShell tools. Only targeted for x64 or ARM64 .NET Core build project.</description>
     <releaseNotes>
+      Version 4.5.1.2
+      - Added support for .NET 8
+      - Removed support for .NET 6
+      Version 4.5.1
       - Update yara to 4.5.1
       - Add support for Windows ARM64
     </releaseNotes>
@@ -17,42 +21,42 @@
     <tags>yara libyara virustotal</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6.2" />
-      <group targetFramework="net6.0" />
+      <group targetFramework="net8.0" />
     </dependencies>
     <references>
       <group targetFramework=".NETFramework4.6.2">
         <reference file="libyara.NET.dll" />
       </group>
-      <group targetFramework="net6.0">
+      <group targetFramework="net8.0">
         <reference file="libyara.NET.dll" />
       </group>
     </references>
   </metadata>
   <files>
     <file src="ref\net462\libyara.NET.dll" target="ref\net462\libyara.NET.dll" />
-    <file src="ref\net6.0\libyara.NET.dll" target="ref\net6.0\libyara.NET.dll" />
+    <file src="ref\net8.0\libyara.NET.dll" target="ref\net8.0\libyara.NET.dll" />
     <file src="ref\net462\libyara.NET.dll" target="lib\net462\libyara.NET.dll" />
-    <file src="ref\net6.0\libyara.NET.dll" target="lib\net6.0\libyara.NET.dll" />
+    <file src="ref\net8.0\libyara.NET.dll" target="lib\net8.0\libyara.NET.dll" />
 
     <file src="x64\Release\net462\libyara.NET.dll" target="runtimes\win-x64\lib\net462\libyara.NET.dll" />
     <file src="x64\Release\net462\libyara.NET.pdb" target="runtimes\win-x64\lib\net462\libyara.NET.pdb" />
     <file src="x64\Release\net462\libyara.NET.xml" target="runtimes\win-x64\lib\net462\libyara.NET.xml" />
 
-    <file src="x64\Release\net6.0\libyara.NET.dll" target="runtimes\win-x64\lib\net6.0\libyara.NET.dll" />
-    <file src="x64\Release\net6.0\libyara.NET.pdb" target="runtimes\win-x64\lib\net6.0\libyara.NET.pdb" />
-    <file src="x64\Release\net6.0\libyara.NET.xml" target="runtimes\win-x64\lib\net6.0\libyara.NET.xml" />
+    <file src="x64\Release\net8.0\libyara.NET.dll" target="runtimes\win-x64\lib\net8.0\libyara.NET.dll" />
+    <file src="x64\Release\net8.0\libyara.NET.pdb" target="runtimes\win-x64\lib\net8.0\libyara.NET.pdb" />
+    <file src="x64\Release\net8.0\libyara.NET.xml" target="runtimes\win-x64\lib\net8.0\libyara.NET.xml" />
 
-    <file src="x64\Release\net6.0\Ijwhost.dll" target="runtimes\win-x64\native\Ijwhost.dll" />
+    <file src="x64\Release\net8.0\Ijwhost.dll" target="runtimes\win-x64\native\Ijwhost.dll" />
 
     <file src="ARM64\Release\net462\libyara.NET.dll" target="runtimes\win-arm64\lib\net462\libyara.NET.dll" />
     <file src="ARM64\Release\net462\libyara.NET.pdb" target="runtimes\win-arm64\lib\net462\libyara.NET.pdb" />
     <file src="ARM64\Release\net462\libyara.NET.xml" target="runtimes\win-arm64\lib\net462\libyara.NET.xml" />
 
-    <file src="ARM64\Release\net6.0\libyara.NET.dll" target="runtimes\win-arm64\lib\net6.0\libyara.NET.dll" />
-    <file src="ARM64\Release\net6.0\libyara.NET.pdb" target="runtimes\win-arm64\lib\net6.0\libyara.NET.pdb" />
-    <file src="ARM64\Release\net6.0\libyara.NET.xml" target="runtimes\win-arm64\lib\net6.0\libyara.NET.xml" />
+    <file src="ARM64\Release\net8.0\libyara.NET.dll" target="runtimes\win-arm64\lib\net8.0\libyara.NET.dll" />
+    <file src="ARM64\Release\net8.0\libyara.NET.pdb" target="runtimes\win-arm64\lib\net8.0\libyara.NET.pdb" />
+    <file src="ARM64\Release\net8.0\libyara.NET.xml" target="runtimes\win-arm64\lib\net8.0\libyara.NET.xml" />
 
-    <file src="ARM64\Release\net6.0\Ijwhost.dll" target="runtimes\win-arm64\native\Ijwhost.dll" />
+    <file src="ARM64\Release\net8.0\Ijwhost.dll" target="runtimes\win-arm64\native\Ijwhost.dll" />
 
     <file src="Microsoft.O365.Security.Native.libyara.NET.Core.targets" target="build\net462\" />
   </files>

--- a/Microsoft.O365.Security.Native.libyara.NET.nuspec
+++ b/Microsoft.O365.Security.Native.libyara.NET.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.O365.Security.Native.libyara.NET</id>
-    <version>4.5.1</version>
+    <version>4.5.1.2</version>
     <authors>Microsoft</authors>
     <license type="expression">BSD-3-Clause</license>
     <projectUrl>https://github.com/Microsoft/libyara.NET/</projectUrl>

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win7-x64;win7-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -22,7 +22,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <ProjectReference Include="..\libyara.NET.Core\libyara.NET.Core.vcxproj" />
   </ItemGroup>
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <Platforms>x64;x86;ARM64</Platforms>
-    <RuntimeIdentifiers>win7-x64;win7-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -36,7 +36,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <ProjectReference Include="..\libyara.NET.Core\libyara.NET.Core.vcxproj" />
   </ItemGroup>
 

--- a/libyara.NET.Core/libyara.NET.Core.vcxproj
+++ b/libyara.NET.Core/libyara.NET.Core.vcxproj
@@ -33,7 +33,7 @@
     <AssemblyName>libyara.NET</AssemblyName>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <CLRSupport>NetCore</CLRSupport>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -65,6 +65,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <TreatWarningAsError>false</TreatWarningAsError>
       <GenerateXMLDocumentationFiles>true</GenerateXMLDocumentationFiles>
+      <DisableSpecificWarnings>4679</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>user32.lib;gdi32.lib;advapi32.lib;crypt32.lib;ws2_32.lib</AdditionalDependencies>


### PR DESCRIPTION
Upgrade libyara package to add support to .net 8.0 the lowest supported version of .NET which will reach end of support on November 10, 2026
Remove support for .NET 6.0 which reached end of support on November 12, 2024